### PR TITLE
Add SVF2 support 

### DIFF
--- a/visuals/aps-viewer-visual/pbiviz.json
+++ b/visuals/aps-viewer-visual/pbiviz.json
@@ -1,10 +1,10 @@
 {
     "visual": {
         "name": "aps-viewer-visual",
-        "displayName": "APS Viewer Visual (0.0.7.0)",
+        "displayName": "APS Viewer Visual (0.0.7.1)",
         "guid": "aps_viewer_visual_a4f2990a03324cf79eb44f982719df44",
         "visualClassName": "Visual",
-        "version": "0.0.7.0",
+        "version": "0.0.7.1",
         "description": "Visual for displaying shared 2D/3D designs from Autodesk Platform Services.",
         "supportUrl": "https://github.com/autodesk-platform-services/aps-powerbi-tools",
         "gitHubUrl": "https://github.com/autodesk-platform-services/aps-powerbi-tools"

--- a/visuals/aps-viewer-visual/src/viewer.utils.ts
+++ b/visuals/aps-viewer-visual/src/viewer.utils.ts
@@ -7,10 +7,16 @@ const runtime: { options: Autodesk.Viewing.InitializerOptions; ready: Promise<vo
     ready: null
 };
 
+declare global {
+    interface Window { DISABLE_INDEXED_DB: boolean; }
+}
+
 export function initializeViewerRuntime(options: Autodesk.Viewing.InitializerOptions): Promise<void> {
     if (!runtime.ready) {
         runtime.options = { ...options };
         runtime.ready = (async function () {
+            window.DISABLE_INDEXED_DB = true;
+
             await loadScript('https://developer.api.autodesk.com/modelderivative/v2/viewers/7.*/viewer3D.js');
             await loadStylesheet('https://developer.api.autodesk.com/modelderivative/v2/viewers/7.*/style.css');
             return new Promise((resolve) => Autodesk.Viewing.Initializer(runtime.options, resolve));

--- a/visuals/aps-viewer-visual/src/visual.ts
+++ b/visuals/aps-viewer-visual/src/visual.ts
@@ -122,7 +122,7 @@ export class Visual implements IVisual {
      */
     private async initializeViewer(): Promise<void> {
         try {
-            await initializeViewerRuntime({ getAccessToken: this.getAccessToken });
+            await initializeViewerRuntime({ env: 'AutodeskProduction2', api: 'streamingV2', getAccessToken: this.getAccessToken });
             this.container.innerText = '';
             this.viewer = new Autodesk.Viewing.GuiViewer3D(this.container);
             this.viewer.start();


### PR DESCRIPTION
This PR aids in adding SVF2 support by disabling the IndexedDb cache using `window.DISABLE_INDEXED_DB = true`

**Note.** In this PR, I hard-coded `env: 'AutodeskProduction2'` and `api: 'steramingV2'` in the viewer initialization options, which point to our US server. For EU customers, they would need to replace it with `env: 'AutodeskProduction2'` and `api: 'steramingV2_EU'` and rebuild the visual card from source codes. 

Demo:
<img width="1669" alt="Svf2Demo" src="https://github.com/autodesk-platform-services/aps-powerbi-tools/assets/5725083/280a8b10-49dc-4c96-af04-eebd8d3249e1">
